### PR TITLE
fixed quote-slider horizontal overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -436,6 +436,7 @@ iframe {
   list-style: none;
   display: block;
   position: relative;
+  overflow: hidden;
 }
 .quote-slider li {
   display: inline-block;


### PR DESCRIPTION
* fixes horizontal scrollbar being there after page loaded
* fixes horizontal scrollbar appearing and disappearing once the `quote-slider` element cycled through all quotes once already